### PR TITLE
feat: add template and task for env file; chore: update build path in…

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,7 @@ tasks:
     cmds:
       - echo "🕙 Initializing project...";
       - task create-docker-compose;
+      - task create-env-file;
       - echo "🎉 Project initialized successfully!";
       - task help
 
@@ -112,6 +113,10 @@ tasks:
   create-docker-compose:
     cmds:
       - cp templates/docker-compose.yml.template docker-compose.yml
+
+  create-env-file:
+    cmds:
+      - cp templates/.env.example .env
 
   help:
     cmds:

--- a/templates/.env.example
+++ b/templates/.env.example
@@ -1,0 +1,16 @@
+DIRECTUS_KEY: "255d861b-5ea1-5996-9aa3-922530ec40b1"
+DIRECTUS_SECRET: "6116487b-cda1-52c2-b5b5-c8022c45e263"
+
+DB_CLIENT: "pg"
+DB_HOST: "database"
+DB_PORT: "5432"
+DB_DATABASE: "directus"
+DB_USER: "directus"
+DB_PASSWORD: "directus"
+
+CACHE_ENABLED: "true"
+CACHE_STORE: "redis"
+REDIS: "redis://cache:6379"
+
+DIRECTUS_ADMIN_EMAIL: "admin@example.com"
+DIRECTUS_ADMIN_PASSWORD: "d1r3ctu5"

--- a/templates/docker-compose.yml.template
+++ b/templates/docker-compose.yml.template
@@ -19,7 +19,7 @@ services:
 
   directus:
     container_name: directus_cms
-    build: /backend
+    build: ./backend
     image: directus/directus:10.7.0
     ports:
       - 8055:8055
@@ -29,29 +29,29 @@ services:
       - ./backend/uploads:/directus/uploads
       - ./backend/extensions:/directus/extensions
     environment:
-      KEY: "255d861b-5ea1-5996-9aa3-922530ec40b1"
-      SECRET: "6116487b-cda1-52c2-b5b5-c8022c45e263"
+      KEY: ${DIRECTUS_KEY}
+      SECRET: ${DIRECTUS_SECRET}
 
-      DB_CLIENT: "pg"
-      DB_HOST: "database"
-      DB_PORT: "5432"
-      DB_DATABASE: "directus"
-      DB_USER: "directus"
-      DB_PASSWORD: "directus"
+      DB_CLIENT: ${DB_CLIENT}
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      DB_DATABASE: ${DB_DATABASE}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
 
-      CACHE_ENABLED: "true"
-      CACHE_STORE: "redis"
-      REDIS: "redis://cache:6379"
+      CACHE_ENABLED: ${CACHE_ENABLED}
+      CACHE_STORE: ${CACHE_STORE}
+      REDIS: ${REDIS}
 
-      ADMIN_EMAIL: "admin@example.com"
-      ADMIN_PASSWORD: "d1r3ctu5"
+      ADMIN_EMAIL: ${DIRECTUS_ADMIN_EMAIL}
+      ADMIN_PASSWORD: ${DIRECTUS_ADMIN_PASSWORD}
 
       # Make sure to set this in production
       # (see https://docs.directus.io/self-hosted/config-options#general)
       # PUBLIC_URL: 'https://directus.example.com'
 
   nextjs:
-    build: /frontend
+    build: ./frontend
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
### Description
A template for environment variables has been added. During `task init` this `.env.example` will be copied to the root file and named `.env`. Furthermore these variables are now used in the `docker-compose.yml` instead of hardcoded strings.

### How to test
- [ ]  Remove your local `docker-compose.yml` and your `.env`, if you have one.
- [ ] Run `task init` 
- [ ] Verify that you have the newer versions of the `docker-compose.yml` and `.env` in your project' root folder
- [ ] Run `task start` and verify that the project still runs as before and there are no errors regarding missing variables

### Notes
Please note that this PR also contains two small fixes in the path of the `build` section of the `docker-compose.yml`